### PR TITLE
added check for api-only Rails apps and prevents assets:precompile from breaking build

### DIFF
--- a/lib/fly-rails/scanner.rb
+++ b/lib/fly-rails/scanner.rb
@@ -64,7 +64,9 @@ module Fly
 
       @redis = @redis_cable || @redis_cache || @sidekiq
 
-      @assets = Dir.exists? 'app/assets'
+      ### api-only ###
+
+      @api = Rails.application.config.api_only
     end
   end
 end

--- a/lib/generators/templates/fly.rake.erb
+++ b/lib/generators/templates/fly.rake.erb
@@ -4,11 +4,13 @@ namespace :fly do
   #  - changes to the filesystem made here DO get deployed
   #  - NO access to secrets, volumes, databases
   #  - Failures here prevent deployment
-<% if @assets -%>
-  task :build => 'assets:precompile'
-<% else -%>
+
+<% if @api -%>
   task :build
+<% else -%>
+  task :build => 'assets:precompile'
 <% end -%>
+
 
 <% unless @litefs -%>
   # RELEASE step:


### PR DESCRIPTION
This fixes prevents a build error involving assets:precompile running on API-only Rails apps.

If a Rails app indicates api_only = true in their application.rb, the build step will skip assets:precompile.

[Reference]
[forum post that mentions this problem](https://community.fly.io/t/rails-api-failed-to-deploy-assets-precompile/7065)


This should be confirmed with a test Rails app that includes the "--api" flag. I am limited by the Free Tier at the moment. 